### PR TITLE
Update Codespaces configuration for compatibility

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js image as the base image
-FROM node:14
+FROM node:18
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,7 @@
     "ms-azuretools.vscode-docker"
   ],
   "postCreateCommand": "npm install",
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+  "forwardPorts": [3000],
+  "postStartCommand": "npm start"
 }


### PR DESCRIPTION
Update the GitHub Codespaces configuration to work with the latest Node.js version and expose port 3000.

* **Update Node.js version**
  - Change the base image in `.devcontainer/Dockerfile` from Node.js 14 to Node.js 18.

* **Expose port 3000 and start application**
  - Add `forwardPorts` setting to expose port 3000 in `.devcontainer/devcontainer.json`.
  - Add `postStartCommand` to run `npm start` in `.devcontainer/devcontainer.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/firstgens-cost-simulator/pull/2?shareId=e902b55a-851a-428c-9ec6-9cc668df76ea).