### PR TITLE
Add start script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "react-scripts build",
-    "deploy": "netlify deploy --prod"
+    "deploy": "netlify deploy --prod",
+    "start": "react-scripts start"
   },
   "dependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
Add a start script to the `package.json` file.

* **package.json**
  - Add a start script to run `react-scripts start` under the "scripts" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/firstgens-cost-simulator/pull/6?shareId=950e3687-b63c-447d-867e-989990347030).